### PR TITLE
Update to 3.15, enabling postfix monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ From command line:
 
 This application now uses the core-only feature of the backup. To keep the integrity of the data and to have a better guarantee of the restoration it is recommended to proceed as follows:
 
-- Stop Gitea service with this command:
+- Stop Monitorix service with this command:
 
 `systemctl stop monitorix.service`
 
-- Launch Gitea backup with this command:
+- Launch Monitorix backup with this command:
 
 `yunohost backup create --app monitorix`
 
 - Backup your data with your specific strategy (could be with rsync, borg backup or just cp). The data is generally stored in `/var/lib/monitorix`.
-- Restart Gitea service with theses command:
+- Restart Monitorix service with theses command:
 
 `systemctl start monitorix.service`
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -46,16 +46,16 @@ From command line:
 
 This application now uses the core-only feature of the backup. To keep the integrity of the data and to have a better guarantee of the restoration it is recommended to proceed as follows:
 
-- Stop Gitea service with this command:
+- Stop Monitorix service with this command:
 
 `systemctl stop monitorix.service`
 
-- Launch Gitea backup with this command:
+- Launch Monitorix backup with this command:
 
 `yunohost backup create --app monitorix`
 
 - Backup your data with your specific strategy (could be with rsync, borg backup or just cp). The data is generally stored in `/var/lib/monitorix`.
-- Restart Gitea service with theses command:
+- Restart Monitorix service with theses command:
 
 `systemctl start monitorix.service`
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://www.monitorix.org/old-versions/monitorix_3.14.0-izzy1_all.deb
-SOURCE_SUM=ea9867a38eb660e6ecdee111ccd133a6c881933399f7a5b6fab412b61b34dfe1
+SOURCE_URL=https://www.monitorix.org/monitorix_3.15.0-izzy1_all.deb
+SOURCE_SUM=0d960b9433ecbaba38d9befe27163644886fb5a466d44f5380576ca975b9d8e4
 # (Optional) Program to check the integrity (sha256sum, md5sum...)
 # default: sha256
 SOURCE_SUM_PRG=sha256sum

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,4 +1,4 @@
-SOURCE_URL=http://www.monitorix.org/monitorix_3.14.0-izzy1_all.deb
+SOURCE_URL=https://www.monitorix.org/old-versions/monitorix_3.14.0-izzy1_all.deb
 SOURCE_SUM=ea9867a38eb660e6ecdee111ccd133a6c881933399f7a5b6fab412b61b34dfe1
 # (Optional) Program to check the integrity (sha256sum, md5sum...)
 # default: sha256

--- a/conf/monitorix.conf
+++ b/conf/monitorix.conf
@@ -92,7 +92,7 @@ secure_log_date_format = %b %e
     libvirt         = n
     process         = y
     serv            = y
-    mail            = n
+    mail            = y
     port            = y
     user            = y
     ftp             = n
@@ -385,17 +385,7 @@ secure_log_date_format = %b %e
         mta = postfix
         greylist = milter-greylist
         rigid = 0, 0, 0, 0, 0
-        limit = 1, 1000, 1000, 1000, 1000
-        <alerts>
-                delvd_enabled = n
-                delvd_timeintvl = 60
-                delvd_threshold = 100
-                delvd_script = /path/to/script.sh
-                mqueued_enabled = n
-                mqueued_timeintvl = 3600
-                mqueued_threshold = 100
-                mqueued_script = /path/to/script.sh
-        </alerts>
+        limit = 1, 1000, 1000, 1000, 1000       
 </mail>
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "A monitoring tools",
         "fr": "Un outils de monitoring"
     },
-    "version": "3.14.0~ynh2",
+    "version": "3.15.0~ynh2",
     "url": "http://monitorix.org",
     "upstream": {
         "license": "GPL-2.0",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,7 @@ app=$YNH_APP_INSTANCE_NAME
 #=================================================
 
 install_dependances() {
-	ynh_install_app_dependencies rrdtool perl libwww-perl libmailtools-perl libmime-lite-perl librrds-perl libdbi-perl libxml-simple-perl libhttp-server-simple-perl libconfig-general-perl pflogsumm libxml-libxml-perl
+	ynh_install_app_dependencies rrdtool perl libwww-perl libmailtools-perl libmime-lite-perl librrds-perl libdbi-perl libdbd-mysql-perl libxml-simple-perl libhttp-server-simple-perl libconfig-general-perl pflogsumm libxml-libxml-perl
 }
 
 get_install_source() {


### PR DESCRIPTION
- update to the actual 3.15 version
- enabling mail (postfix) monitoring
- add the missing `libdbd-mysql-perl` dependency