### PR TITLE
List `mariadb-server` as dependency.

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,7 +10,7 @@ systemd_user=root
 #=================================================
 
 install_dependances() {
-	ynh_install_app_dependencies rrdtool perl libwww-perl libmailtools-perl libmime-lite-perl librrds-perl libdbi-perl libdbd-mysql-perl libxml-simple-perl libhttp-server-simple-perl libconfig-general-perl pflogsumm libxml-libxml-perl
+	ynh_install_app_dependencies rrdtool perl libwww-perl libmailtools-perl libmime-lite-perl librrds-perl libdbi-perl libdbd-mysql-perl libxml-simple-perl libhttp-server-simple-perl libconfig-general-perl pflogsumm libxml-libxml-perl mariadb-server
 }
 
 get_install_source() {


### PR DESCRIPTION
Fix `bookworm` compatibility and general would-be-if-this-used-packaging-v2 linter warning.