### PR TITLE
Fix php installation detection and config panel

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -71,8 +71,10 @@ name.en = "Monitorix configuration"
 
         [config.system.system_alerts_loadavg_threshold]
         ask.en = "Load average threshold"
-        type = "range"
-        help = "This is the value that needs to be reached or exceeded within the specified time period in loadavg_timeintvl to trigger the mechanism for a particular action, which in this case is the execution of an external alert script.\n\nThe value of this option is compared against the last 15 minutes of CPU load average."
+        type = "string"
+        pattern.regexp = '^\d+\.\d$'
+        pattern.error = 'Should be a float number. By example "5.1"'
+        help = "This is the value that needs to be reached or exceeded within the specified time period in loadavg_timeintvl to trigger the mechanism for a particular action, which in this case is the execution of an external alert script.\n\nThe value of this option is compared against the last 15 minutes of CPU load average. By example '5.1'"
 
     [config.disk]
     name = "Disk usage"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -65,7 +65,8 @@ load_vars() {
     else
         readonly redis_installed=false
     fi
-    if _ynh_apt_package_is_installed 'php*-fpm'; then
+    if dpkg-query --show --showformat='${db:Status-Status}\n' "php*-fpm" 2> /dev/null \
+        | grep --quiet "^installed$" &> /dev/null; then
         readonly phpfpm_installed=true
     else
         readonly phpfpm_installed=false

--- a/scripts/restore
+++ b/scripts/restore
@@ -43,7 +43,7 @@ ynh_config_add_logrotate "/var/log/$app"
 #=================================================
 ynh_script_progression "Reloading NGINX web server and $app's service..."
 
-ynh_systemctl --service="$app" --action=start --log_path='systemd' --wait_until=' - Ok, ready.'
+ynh_systemctl --service="$app" --action=restart --log_path='systemd' --wait_until=' - Ok, ready.'
 # when we change the value of 'listen [::1]:xxx;' nginx don't reload correctly the config, so force to restart to ensure that the new config are loaded
 ynh_systemctl --service=nginx.service --action=restart
 ynh_systemctl --service=nginx --action=reload


### PR DESCRIPTION
## Problem

- Php installation not correctly detected

## Solution

- Fix it

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
