### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A system monitoring tool
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://monitorix.org)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://www.fibranet.cat/monitorix/)
-[![Version: 3.16.0~ynh4](https://img.shields.io/badge/Version-3.16.0~ynh4-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/monitorix/)
+[![Version: 3.16.0~ynh5](https://img.shields.io/badge/Version-3.16.0~ynh5-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/monitorix/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/monitorix"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/conf/monitorix.conf
+++ b/conf/monitorix.conf
@@ -720,7 +720,7 @@ squid_log       = /var/log/squid/access.log
 # PORT graph
 # -----------------------------------------------------------------------------
 <port>
-    max = 50
+    max = 200
     rule = 24000
     list = {{ ssh_port }}v4, {{ ssh_port }}v6, 25v4, 25v6, 80v4, 80v6, 443v4, 443v6, 587v4, 587v6, 993v4, 993v6
     {%- for port_info in port_infos.splitlines() -%}

--- a/conf/monitorix.conf
+++ b/conf/monitorix.conf
@@ -554,6 +554,7 @@ squid_log       = /var/log/squid/access.log
         /home/yunohost.backup = Yunohost backups
     </dirmap>
     graphs_per_row = 2
+    refresh_interval = {{ du_refresh_interval }}
     rigid = 0
     limit = 100
 </du>

--- a/config_panel.toml
+++ b/config_panel.toml
@@ -95,6 +95,17 @@ name.en = "Monitorix configuration"
         type = "number"
         help = "Percentage to reach to send alert."
 
+    [config.du]
+    name = "Directory usage"
+
+        [config.du.du_refresh_interval]
+        ask.en = "Refresh interval in seconds"
+        type = "number"
+        min = 60
+        max = 86400
+        default = 3600
+        help = "This is an option to reduce the execution of the du command and undesired side effects caused by this. Default value 0 means normal refresh with all other plots. Values are from 60 to 86400. Keep in mind that changing the refresh_interval is possible without loosing history but changing the interval to a smaller one will introduce gaps in the data at the transition point."
+
     [config.mail]
     name = "Mail statistics"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Monitorix"
 description.en = "A system monitoring tool"
 description.fr = "Un outil de monitoring système"
 
-version = "3.16.0~ynh4"
+version = "3.16.0~ynh5"
 
 maintainers = ["Josué Tille"]
 

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -209,8 +209,8 @@ configure_alerts_email() {
                       mail.delvd-alert.sh
     do
         alias_path="$install_dir/$alias_file"
-        if [ ! -h "$alias_path" ]; then
-            if [ -e "$alias_path" ]; then
+        if [ ! -h "$alias_path" ] || [ ! -e "$alias_path" ]; then
+            if [ -e "$alias_path" ] || [ -h "$alias_path" ]; then
                 ynh_safe_rm "$alias_path"
             fi
             ln -s "$install_dir/monitorix-alert.sh" "$install_dir/$alias_file"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -232,6 +232,7 @@ ensure_vars_set() {
     ynh_app_setting_set_default --key=disk_alerts_loadavg_enabled --value=false
     ynh_app_setting_set_default --key=disk_alerts_loadavg_timeintvl --value=3600
     ynh_app_setting_set_default --key=disk_alerts_loadavg_threshold --value=98
+    ynh_app_setting_set_default --key=du_refresh_interval --value=3600 # every hours
     ynh_app_setting_set_default --key=mail_delvd_enabled --value=n
     ynh_app_setting_set_default --key=mail_delvd_timeintvl --value=60
     ynh_app_setting_set_default --key=mail_delvd_threshold --value=100

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -111,8 +111,8 @@ def generate_port_info(proto, port):
             name = "Port_" + port
     return "%s,%s,%s" % (port, proto, name)
 
-result = [generate_port_info("tcp", port) for port in tcp_ports] + \
-         [generate_port_info("tcp", port) for port in udp_ports]
+result = [generate_port_info("tcp", port.replace('-',':')) for port in tcp_ports] + \
+         [generate_port_info("udp", port.replace('-',':')) for port in udp_ports]
 result.sort()
 print('\n'.join(result))
 EOF

--- a/sources/update_config_if_needed.sh
+++ b/sources/update_config_if_needed.sh
@@ -52,6 +52,8 @@ if "$status_dirty"; then
     disk_alerts_loadavg_timeintvl="$(ynh_app_setting_get --key=disk_alerts_loadavg_timeintvl)"
     disk_alerts_loadavg_threshold="$(ynh_app_setting_get --key=disk_alerts_loadavg_threshold)"
 
+    du_refresh_interval="$(ynh_app_setting_get --key=du_refresh_interval)"
+
     mail_delvd_enabled="$(ynh_app_setting_get --key=mail_delvd_enabled)"
     mail_delvd_timeintvl="$(ynh_app_setting_get --key=mail_delvd_timeintvl)"
     mail_delvd_threshold="$(ynh_app_setting_get --key=mail_delvd_threshold)"


### PR DESCRIPTION
## Problem

- https://github.com/yunoHost-Apps/monitorix_ynh/issues/86
- port graphe broken

## Solution

- Add a new settings to avoid to refresh du graph at the same frequency than the other graphe as it could be expensive.
- Fix differents bugs

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
